### PR TITLE
Update README.md: Clarify installation requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ ADCSKiller is a Python-based tool designed to automate the process of discoverin
 Since this tool relies on Certipy and Coercer, both tools have to be installed first.
 
 ```bash
-git clone https://github.com/ly4k/Certipy && cd Certipy && python3 setup.py install
-git clone https://github.com/p0dalirius/Coercer && cd Coercer && pip install -r requirements.txt && python3 setup.py install
-git clone https://github.com/grimlockx/ADCSKiller/ && cd ADCSKiller && pip install -r requirements.txt
+python3 -V # Needs at least Python 3.7 installed
+git clone https://github.com/ly4k/Certipy && pushd Certipy && python3 setup.py install && popd
+git clone https://github.com/p0dalirius/Coercer && pushd Coercer && pip install -r requirements.txt && python3 setup.py install && popd
+git clone https://github.com/grimlockx/ADCSKiller/ && pushd ADCSKiller && pip install -r requirements.txt && popd
 ```
 
 ## Usage


### PR DESCRIPTION
Python 3.7 is the minimum version, apparently, and I did a tiny update to not have `Certify/Coercer/ADCSKiller` as chained directories via `pushd`/`popd`.